### PR TITLE
add keys for move current tab, fix key press check

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -38,6 +38,8 @@ Other Linux systems:
 ## Keys
 - `Control + Page_Up` - Previous tab
 - `Control + Page_Down` - Next tab
+- `Control + Shift + Page_Up` - Move current tab before previous tab
+- `Control + Shift + Page_Down` - Move current tab after next tab
 - `Control + Shift + T` - New tab
 - `Control + F4` - Close tab
 

--- a/urxvt_tabbed/config.py
+++ b/urxvt_tabbed/config.py
@@ -104,6 +104,8 @@ class ConfigDefaults(Config):
 			'keymap': {
 				'prev_tab': 'Control + Page_Up',
 				'next_tab': 'Control + Page_Down',
+				'move_tab_prev': 'Control + Shift + Page_Up',
+				'move_tab_next': 'Control + Shift + Page_Down',
 				'new_tab': 'Control + Shift + T',
 				'close_tab': 'Control + F4',
 			}

--- a/urxvt_tabbed/urxvt_tabbed.py
+++ b/urxvt_tabbed/urxvt_tabbed.py
@@ -12,7 +12,7 @@ from .config import KeyPress
 gdk_events = GdkEvents()
 
 def is_key_pressed(key, event_key):
-	return event_key.key == key.key and event_key.modifier_flags&key.modifier_flags == key.modifier_flags
+	return event_key.key == key.key and event_key.modifier_flags == key.modifier_flags
 
 class UrxvtTabbedWindow(Gtk.Window):
 	'''
@@ -107,6 +107,18 @@ class UrxvtTabbedWindow(Gtk.Window):
 			self.notebook.set_current_page((self.notebook.get_current_page()-1)%len(self.tabs))
 		elif is_key_pressed(keymap['next_tab'], event_key):
 			self.notebook.set_current_page((self.notebook.get_current_page()+1)%len(self.tabs))
+		elif is_key_pressed(keymap['move_tab_prev'], event_key):
+			tabs = self.tabs
+			old_pos = self.notebook.get_current_page()
+			new_pos = (old_pos - 1 + len(tabs)) % len(tabs)
+			tabs[old_pos], tabs[new_pos] = tabs[new_pos], tabs[old_pos]
+			self.notebook.reorder_child(tabs[new_pos].rxvt_socket, new_pos)
+		elif is_key_pressed(keymap['move_tab_next'], event_key):
+			tabs = self.tabs
+			old_pos = self.notebook.get_current_page()
+			new_pos = (old_pos + 1 + len(tabs)) % len(tabs)
+			tabs[old_pos], tabs[new_pos] = tabs[new_pos], tabs[old_pos]
+			self.notebook.reorder_child(tabs[new_pos].rxvt_socket, new_pos)
 
 	def on_page_removed(self, notebook, tab, page_num):
 		self.tabs.pop(page_num)


### PR DESCRIPTION
I am not familiar with Gtk and its notebook, so I might have done something unnecessary to arrange the current tab. You might need to check to see if there is simpler way to move the tab around.

The following is the commit message:

Note that the key checking would cause confusion when with `Ctrl + Shift` and `Ctrl` at the same time. The bitwise operation and the final check would always in favor of `Ctrl` case since `Ctrl + Shift` & `Ctrl` == `Ctrl`.

This would render other more complex keybinding case useless if simpler case is checked before those.

So, I simply remove the `&` with mask and only do `==`.
